### PR TITLE
Extend the zsh configuration

### DIFF
--- a/dotfiles/dot_config/zsh/dot_zprofile
+++ b/dotfiles/dot_config/zsh/dot_zprofile
@@ -56,6 +56,8 @@ path=(
   /opt/{homebrew,local}/{,s}bin(N)
   /usr/local/{,s}bin(N)
   /usr/local/opt/go@1.17/bin
+  $HOME/.krew/bin
+  $HOME/.cargo/bin
   $HOME/.npm-packages/bin
   $HOME/.rd/bin
   $DOTFILES/bin

--- a/dotfiles/dot_config/zsh/modules/refnode/init.zsh
+++ b/dotfiles/dot_config/zsh/modules/refnode/init.zsh
@@ -28,6 +28,10 @@ alias lla='exa --long --group --git --all'
 
 # shorties
 alias k='kubectl'
+alias g='git'
+alias tg='topgrade'
+alias cz='chezmoi'
+alias czd='chezmoi cd'
 
 # linux compatibility
 alias ldd='otool -L'

--- a/dotfiles/dot_zshenv
+++ b/dotfiles/dot_zshenv
@@ -14,6 +14,10 @@ export DOTFILES="${HOME}/.dotfiles"
 # Define ZDOTDIR to keep the majority of zsh config out of users home root
 export ZDOTDIR="${HOME}/.config/zsh"
 
+# On my workplaces I use podman.
+# Set DOCKER_HOST to the default podman machine socket.
+export DOCKER_HOST="unix://${HOME}/.local/share/containers/podman/machine/podman-machine-default/podman.sock"
+
 # If present source a workspace local zshenv file.
 if [ -s "${HOME}/.zshenv.local" ]; then
     source "${HOME}/.zshenv.local"


### PR DESCRIPTION
Alias extensions for git, topgrade and chezmoi, podman as docker replacement and search path extensions for krew and cargo.