### PR TITLE
feat(topgrade): transfer config to chezmoi control

### DIFF
--- a/dotfiles/dot_config/topgrade.toml
+++ b/dotfiles/dot_config/topgrade.toml
@@ -1,0 +1,24 @@
+assume_yes = true
+
+only = [
+  "system",
+  "brew_formula",
+  "brew_cask",
+  "krew",
+  "mas",
+  "custom_commands",
+  "containers",
+  "rustup",
+]
+
+run_in_tmux = false
+set_title = false
+display_time = true
+cleanup = true
+
+[pre_commands]
+"Install Brewfile managed packages" = "brew bundle install --no-upgrade"
+
+[commands]
+"Brewfile Consistency Check" = "brew bundle cleanup --force"
+"Helm Charts Repos Update" = "helm repo update"


### PR DESCRIPTION
I use topgrade to keep a list of different package managers and resources up-to-date. Transfer the topgrade config to chezmoi control.