### PR TITLE
fix(zsh): merge .zshenv.local parts into .zshenv

### DIFF
--- a/dotfiles/dot_zshenv
+++ b/dotfiles/dot_zshenv
@@ -22,6 +22,9 @@ export GNUPGHOME="${HOME}/.gnupg"
 # Set DOCKER_HOST to the default podman machine socket.
 export DOCKER_HOST="unix://${HOME}/.local/share/containers/podman/machine/podman-machine-default/podman.sock"
 
+# To use kind with podman, the env var must be present.
+export KIND_EXPERIMENTAL_PROVIDER=podman
+
 # If present source a workspace local zshenv file.
 if [ -s "${HOME}/.zshenv.local" ]; then
     source "${HOME}/.zshenv.local"


### PR DESCRIPTION
The .zshenv.local was used for overriding env vars for workplace local
purposes. As chezmoi provides a templating, the overriding is not
necessary anymore.
