### PR TITLE
feat(rust/cargo): initial add cargo config file

### DIFF
--- a/dotfiles/dot_cargo/config.toml.tmpl
+++ b/dotfiles/dot_cargo/config.toml.tmpl
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
To install packages with cargo on my workplace I need to ask cargo to
use the git cli because of the authentication workflow.
