### PR TITLE
fix(zsh/mod/ssh): disable ssh-key autoload because of external token use

### DIFF
--- a/dotfiles/dot_config/zsh/dot_zpreztorc
+++ b/dotfiles/dot_config/zsh/dot_zpreztorc
@@ -172,7 +172,7 @@ zstyle ':prezto:module:prompt' theme 'powerlevel10k'
 #
 
 # Set the SSH identities to load into the agent.
-# zstyle ':prezto:module:ssh:load' identities 'id_rsa' 'id_rsa2' 'id_github'
+zstyle ':prezto:module:ssh:load' identities ''
 
 #
 # Syntax Highlighting


### PR DESCRIPTION
Because of a different setup with Yubikey, I do not need the autoload of
ssh private keys by the ssh-agent. Therefore explicit empty the list of
keys.
